### PR TITLE
feat: benalohBin

### DIFF
--- a/src/she.js
+++ b/src/she.js
@@ -523,6 +523,32 @@ const setupFactory = (createModule, getRandomValues) => {
       deserialize (s) {
         this._setter(mod.shePublicKeyDeserialize, s)
       }
+
+      benalohBin = ( c, randHistory) => {
+        let method
+        if (exports.CipherTextG1.prototype.isPrototypeOf(c)) {
+          method = 'encG1'
+        } else if (exports.CipherTextG2.prototype.isPrototypeOf(c)) {
+          method = 'encG2'
+        } else if (exports.CipherTextGT.prototype.isPrototypeOf(c)) {
+          method = 'encGT'
+        } else {
+          throw ('exports.PublicKey.benalohBin:not supported')
+        }
+
+        const c0 = this[method](0, randHistory)
+
+        const serializedC = c.serializeToHexStr()
+        if(c0.serializeToHexStr() === serializedC ) return 0
+
+        const c1 = this[method](1, randHistory)
+
+        if(c1.serializeToHexStr() === serializedC) return 1
+
+        throw ('exports.PublicKey.benalohBin:c not matched')
+
+      }
+
       encG1 (m, rh = undefined) {
         if (rh) rh._set()
         const r = callEnc(mod._sheEncG1, exports.CipherTextG1, this, m)

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,7 @@ const curveTest = (curveType, name) => {
     .then(() => {
       try {
         console.log(`name=${name}`)
+        benalohTest()
         controlledRandomValues()
         minimumTest()
         zkpDecTest()
@@ -86,6 +87,55 @@ function controlledRandomValues () {
     }
   })
 }
+
+function benalohTest () {
+  const sec = new she.SecretKey()
+  sec.setByCSPRNG()
+  const pub = sec.getPublicKey()
+  const methods = ['encG1', 'encG2', 'encGT', 'encWithZkpBinG2', 'encWithZkpBinG1']
+  methods.forEach(method => {
+    const rh0 = new she.RandHistory() // empty
+    const r0 = pub[method](0, rh0)
+    const rh1 = new she.RandHistory() // empty
+    const r1 = pub[method](1, rh1) 
+    if (method.indexOf('Zkp') === -1) {
+      assert.equal(pub.benalohBin(r0,rh0), 0)
+      assert.equal(pub.benalohBin(r1,rh1), 1)
+      try {
+        pub.benalohBin(r0,rh1)
+        throw 'error'
+      } catch(e){
+        assert.equal(e,'exports.PublicKey.benalohBin:c not matched')
+      }
+      try {
+        pub.benalohBin(r1,rh0)
+        throw 'error'
+      } catch(e){
+        assert.equal(e,'exports.PublicKey.benalohBin:c not matched')
+      }
+    } else {
+      r0.forEach((v, i) => {
+        // Do not test zkp
+        if((r0.length === 3 && i ===2 || r0.length === 2 && i === 1)) return 
+        assert.equal(pub.benalohBin(r0[i],rh0), 0)
+        assert.equal(pub.benalohBin(r1[i],rh1), 1)
+        try {
+          pub.benalohBin(r0[i],rh1)
+          throw 'error'
+        } catch(e){
+          assert.equal(e,'exports.PublicKey.benalohBin:c not matched')
+        }
+        try {
+          pub.benalohBin(r1[i],rh0)
+          throw 'error'
+        } catch(e){
+          assert.equal(e,'exports.PublicKey.benalohBin:c not matched')
+        }
+      })
+    }
+  })
+}
+
 
 function encDecTest () {
   const sec = new she.SecretKey()


### PR DESCRIPTION
Simple exaustive benaloh system for 0 or 1 cypher texts with sufficient performance.

This method allow to challenge and retrieve an original value from a cipher text with a provided secret history.

@herumi , i know it's not a real mathematical solution but i think it could help some one in the futur if they search to achieve some check easily to prove that a client correctly cypher some bin cypher texts.

Disclaimer: Here it's just the check implementation, benaloh protocol need many additional systems like **cypher text invalidation**, a challenged cypher text should not be counted in the final homo addition/count.